### PR TITLE
remove unnecessary crypto dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
     "name": "kache-buster",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "cache busting gulp package",
     "dependencies": {},
     "dependencies": {
         "cheerio": "^0.19.0",
-        "crypto": "^0.0.3",
         "through2": "^2.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
See https://medium.com/@rmehlinger/crypto-collision-f41c206de27b. This package has no license and no tests, and masks a built in NodeJS library. Thankfully, Node does not allow its crypto package to be overwritten by this thing, so requiring it doesn't actually do anything.